### PR TITLE
Add missing src/footer.vim

### DIFF
--- a/src/footer.vim
+++ b/src/footer.vim
@@ -1,0 +1,3 @@
+
+let &cpo = s:original_cpo
+unlet! s:original_cpo s:bg s:i


### PR DESCRIPTION
Fixes:

> make[1]: *** No rule to make target 'src/footer.vim', needed by 'vim/syntax/tmux.vim'.  Stop.