### PR TITLE
Remove contained option from #{} format strings

### DIFF
--- a/vim/syntax/tmux.vim
+++ b/vim/syntax/tmux.vim
@@ -37,7 +37,7 @@ syn region tmuxString start=+'+ skip=+\\\\\|\\'\|\\$+ excludenl end=+'+ end='$' 
 
 " TODO: Figure out how escaping works inside of #(...) and #{...} blocks.
 syn region tmuxFormatString start=/#[#DFhHIPSTW]/ end=// contained keepend
-syn region tmuxFormatString start=/#{/ skip=/#{.\{-}}/ end=/}/ contained keepend
+syn region tmuxFormatString start=/#{/ skip=/#{.\{-}}/ end=/}/ keepend
 syn region tmuxFormatString start=/#(/ skip=/#(.\{-})/ end=/)/ contained keepend
 
 hi def link tmuxFormatString      Identifier


### PR DESCRIPTION
For example in
```
%if #{some_condition}
...
```
`#{some_condition}` is highlighted as comment.